### PR TITLE
Suppress defining bidirectional relations

### DIFF
--- a/spec/domains/medical/hospital-repository.coffee
+++ b/spec/domains/medical/hospital-repository.coffee
@@ -1,0 +1,20 @@
+LoopbackRepository = require('../../base-domain-loopback').LoopbackRepository
+
+###*
+a repository for hospital
+
+@class HospitalRepository
+@extends LoopbackRepository
+###
+class HospitalRepository extends LoopbackRepository
+    ###*
+    model name to create
+
+    @property modelName
+    @static
+    @protected
+    @type String
+    ###
+    @modelName: 'hospital'
+
+module.exports = HospitalRepository

--- a/spec/domains/medical/hospital.coffee
+++ b/spec/domains/medical/hospital.coffee
@@ -1,0 +1,24 @@
+Entity = require('base-domain').Entity
+
+###*
+entity class for hospital
+
+@class Hospital
+@extends Entity
+###
+class Hospital extends Entity
+
+    ###*
+    property types
+    key:   property name
+    value: type
+
+    @property properties
+    @static
+    @protected
+    @type Object
+    ###
+    @properties:
+        name: @TYPES.STRING
+
+module.exports = Hospital

--- a/spec/domains/medical/patient-repository.coffee
+++ b/spec/domains/medical/patient-repository.coffee
@@ -1,0 +1,20 @@
+LoopbackRepository = require('../../base-domain-loopback').LoopbackRepository
+
+###*
+a repository for patient
+
+@class PatientRepository
+@extends LoopbackRepository
+###
+class PatientRepository extends LoopbackRepository
+    ###*
+    model name to create
+
+    @property modelName
+    @static
+    @protected
+    @type String
+    ###
+    @modelName: 'patient'
+
+module.exports = PatientRepository

--- a/spec/domains/medical/patient.coffee
+++ b/spec/domains/medical/patient.coffee
@@ -1,0 +1,27 @@
+Entity = require('base-domain').Entity
+Hospital = require('./hospital')
+
+###*
+entity class for patient
+
+@class Patient
+@extends Entity
+###
+class Patient extends Entity
+
+    ###*
+    property types
+    key:   property name
+    value: type
+
+    @property properties
+    @static
+    @protected
+    @type Object
+    ###
+    @properties:
+        name: @TYPES.STRING
+        hospital: @TYPES.MODEL 'hospital',
+            isOutOfAggregate: true
+
+module.exports = Patient

--- a/spec/lib/setting-exporter.coffee
+++ b/spec/lib/setting-exporter.coffee
@@ -33,11 +33,21 @@ describe 'SettingExporter', ->
             assert playerDefObj.relations.song.type is 'hasMany'
 
         it 'does not append "hasMany" relations to non-has-many relations', ->
+            console.log @modelDefinitions
             for entityName in ['instrument', 'song']
                 rels = @modelDefinitions[entityName].relations
                 for relProp, relInfo of rels
                     assert.notEqual relInfo.type, 'hasMany'
                     assert relInfo.type is 'belongsTo'
+
+        context 'medical', ->
+            beforeEach ->
+                @domain = require('../create-facade').create(dirname: __dirname + '/../domains/medical')
+                @loopbackDefinitions = new SettingExporter(@domain).export()
+                @modelDefinitions = @loopbackDefinitions.models
+
+            it.only 'does not append "hasMany" relations to a model that is out of aggregate', ->
+                assert Object.keys(@modelDefinitions.hospital.relations).length is 0
 
 
 

--- a/spec/lib/setting-exporter.coffee
+++ b/spec/lib/setting-exporter.coffee
@@ -33,7 +33,6 @@ describe 'SettingExporter', ->
             assert playerDefObj.relations.song.type is 'hasMany'
 
         it 'does not append "hasMany" relations to non-has-many relations', ->
-            console.log @modelDefinitions
             for entityName in ['instrument', 'song']
                 rels = @modelDefinitions[entityName].relations
                 for relProp, relInfo of rels
@@ -46,7 +45,7 @@ describe 'SettingExporter', ->
                 @loopbackDefinitions = new SettingExporter(@domain).export()
                 @modelDefinitions = @loopbackDefinitions.models
 
-            it.only 'does not append "hasMany" relations to a model that is out of aggregate', ->
+            it 'does not append "hasMany" relations to a model that is out of aggregate', ->
                 assert Object.keys(@modelDefinitions.hospital.relations).length is 0
 
 

--- a/src/lib/setting-exporter.coffee
+++ b/src/lib/setting-exporter.coffee
@@ -123,6 +123,7 @@ class SettingExporter
 
         for lbModelName, definition of definitions
             for prop, typeInfo of definition.getEntityProps()
+                continue if typeInfo.isOutOfAggregate
                 relLbModelName = @getLbModelName(typeInfo.model)
                 continue if not relLbModelName
                 relModelDefinition = definitions[relLbModelName]


### PR DESCRIPTION
Introducing "DDD Aggregate" properly

http://martinfowler.com/bliki/DDD_Aggregate.html

Currently, properties that are included in an entity are treated as elements in a same Aggregate.

```coffee:a.coffee
class A extends Entity
```

```coffee:b.coffee
class B extends Entity
    @properties:
        a: @TYPES.MODEL 'a'
```

These definitions indicates below statements.

- `A` is a Aggregate Root
- `B` is a Aggregate Element

And base-domain-loopback defines a Loopback API `/a/{id}/b`. But I think this behavior causes confusion. From class definitions, `A` is just a property of `B`, not an Aggregate Element.

At properties definition, base-domain allows to specify options, fortunately. If an option `isOutOfAggregate` is specified, suppress a defining the Loopback API like `/a/{id}/b`.

```coffee:yet-another-b.coffee
class B extends Entity
    @properties:
        a: @TYPES.MODEL 'a',
            isOutOfAggregate: true
```
